### PR TITLE
feat: allow service workers over https

### DIFF
--- a/public/js/main/IndexController.js
+++ b/public/js/main/IndexController.js
@@ -17,7 +17,7 @@ IndexController.prototype._openSocket = function() {
 
   // create a url pointing to /updates with the ws protocol
   var socketUrl = new URL('/updates', window.location);
-  socketUrl.protocol = 'ws';
+  socketUrl.protocol = window.location.protocol === "https:" ? 'wss' : 'ws';
 
   if (latestPostDate) {
     socketUrl.search = 'since=' + latestPostDate.valueOf();


### PR DESCRIPTION
- bug fix when running demo with online IDE

Since SSL wasn't talked about in-depth in the videos, I'm not sure if the bug is purposely placed in the code.
