### PR TITLE
switch to using sendFile to fix issue introduced by express 4.16.0

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import zlib from 'zlib';
 import fs from 'fs';
+import path from 'path';
 import os from 'os';
 import compression from 'compression';
 import {Server as WebSocketServer} from 'ws';
@@ -77,9 +78,9 @@ export default class Server {
     this._app.use('/css', express.static('../public/css', staticOptions));
     this._app.use('/imgs', express.static('../public/imgs', staticOptions));
     this._app.use('/avatars', express.static('../public/avatars', staticOptions));
-    this._app.use('/sw.js', express.static('../public/sw.js', staticOptions));
-    this._app.use('/sw.js.map', express.static('../public/sw.js.map', staticOptions));
-    this._app.use('/manifest.json', express.static('../public/manifest.json', staticOptions));
+    this._app.use('/sw.js', (req, res) => res.sendFile(path.resolve('../public/sw.js'), staticOptions));
+    this._app.use('/sw.js.map', (req, res) => res.sendFile(path.resolve('../public/sw.js.map'), staticOptions));
+    this._app.use('/manifest.json', (req, res) => res.sendFile(path.resolve('../public/manifest.json'), staticOptions));
 
     this._app.get('/', (req, res) => {
       res.send(indexTemplate({


### PR DESCRIPTION
I was going through the course on Udacity and could not get sw.js, sw.js.map or manifest.json to serve up.  Express 4.16.0 seems to have introduced this when using express.static to refer to an individual file (https://github.com/expressjs/express/issues/3436).  I applied the solution suggested in that link and am now able to serve up these files.