### PR TITLE
Bump gulp-sass version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-handlebars": "^4.0.0",
     "gulp-load-plugins": "^0.10.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "handlebars": "^3.0.3",


### PR DESCRIPTION
I noticed that many people having trouble with node install so made a small research and found out that the used **gulp-sass version "^2.0.4"** in the devDependencies has a dependency of **node-sass : "^3.4.2"** which can be **satisfied by version 3.13.1**. But version 3.13.1 **supports only node versions till 7** [(https://github.com/sass/node-sass/releases/tag/v3.13.1)](release v3.13.1).
The easiest solution to the problem, which will save a lot of trouble for windows users using the node versions 8 and 9, is to **bump gulp-sass version to the latest "^3.1.0"** which requires the latest node-sass [https://github.com/sass/node-sass/releases/tag/v4.6.0](release v4.6.0).

This way we avoid the need for building the module from source and the installation of **windows-build-tools** node package.

**Note:** There will be some warnings in the initial install, because of unmet optional dependencies.

