### PR TITLE
Update package.json to be able to install via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-handlebars": "^4.0.0",
     "gulp-load-plugins": "^0.10.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "handlebars": "^3.0.3",


### PR DESCRIPTION
There is an error, when try to install the old gulp-sass so please
update it to a new version. The binaries for the old one aren't exist
anymore.