### PR TITLE
Adds `package-lock.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 npm-debug.log
 pointless_change
+package-lock.json


### PR DESCRIPTION
Going through the [service worker course on udacity](https://classroom.udacity.com/courses/ud899) and running `npm install` generates a `package.json` file thereby automatically creating a diff.  May confuse newb users when they run `npm reset --hard` as there is still a diff.