### PR TITLE
Adding ES6 env

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
  "root": true,
  "env": {
    "browser": true,
-   "node": true
+   "node": true,
+   "es6": true
  },
 
  "parser": "babel-eslint",


### PR DESCRIPTION
This will stop ESLint from throwing: 'Promise' is not defined.
(no-undef)