### PR TITLE
Issue #48: Fix images not serving with the correct response Headers

### DIFF
--- a/server/Server.js
+++ b/server/Server.js
@@ -101,6 +101,9 @@ export default class Server {
     this._app.get('/photos/:farm-:server-:id-:secret-:type.jpg', (req, res) => {
       const flickrUrl = `http://farm${req.params.farm}.staticflickr.com/${req.params.server}/${req.params.id}_${req.params.secret}_${imgSizeToFlickrSuffix[req.params.type]}.jpg`;
       const flickrRequest = http.request(flickrUrl, flickrRes => {
+        Object.keys(flickrRes.headers).forEach((header) => {
+          res.setHeader(header, flickrRes.headers[header]);
+        });          
         flickrRes.pipe(res);
       });
 


### PR DESCRIPTION
This fixes the images returning to the client without the headers causing the content-type to be interpreted as text/plain and caching it as text when using the cache with the service worker

Before change
<img width="768" alt="screen shot 2018-01-17 at 7 56 40 am" src="https://user-images.githubusercontent.com/35116035/35044135-406273f2-fb5d-11e7-86bc-f348c1cf7b7a.png">

After Change
<img width="772" alt="screen shot 2018-01-17 at 7 58 12 am" src="https://user-images.githubusercontent.com/35116035/35044152-5377a3cc-fb5d-11e7-9cd5-cc377153c027.png">
